### PR TITLE
Add pstokes tail contribution

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [ww3dev]
-tag = dev/unified_0.0.8
+tag = dev/unified_0.0.9
 protocol = git
 repo_url = https://github.com/ESCOMP/WW3.git
 local_path = WW3

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -43,11 +43,6 @@
   <entry id="WW3_MODDEF">
     <type>char</type>
     <default_value>unset</default_value>
-    <values>
-      <value grid="_w%ww3a">$DIN_LOC_ROOT/wav/ww3/ww3a.mod_def.ww3.wwver7.14.230921</value>
-      <value grid="_w%gx1v7">$DIN_LOC_ROOT/wav/ww3/gx1v7.mod_def.ww3.wwver7.14.230921</value>
-      <value grid="_w%wtx0.66v1">$DIN_LOC_ROOT/wav/ww3/wt061.mod_def.ww3.wwver7.14.230921</value>
-    </values>
     <group>case_comp</group>
     <file>env_build.xml</file>
     <desc>mod_def file to use. The value depends on the switches, if you have an unstructured mesh and the
@@ -59,9 +54,9 @@
     <type>char</type>
     <default_value>$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}</default_value>
     <values>
-      <value grid="_w%ww3a">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.230921</value>
-      <value grid="_w%gx1v7">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.230921</value>
-      <value grid="_w%wtx0.66v1">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.230921</value>
+      <value grid="_w%ww3a">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.231018</value>
+      <value grid="_w%gx1v7">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.231018</value>
+      <value grid="_w%wtx0.66v1">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.231018</value>
     </values>
     <group>case_comp</group>
     <file>env_build.xml</file>

--- a/cime_config/testdefs/testlist_ww3dev.xml
+++ b/cime_config/testdefs/testlist_ww3dev.xml
@@ -3,6 +3,7 @@
   <test name="SMS_D" grid="TL319_t061" compset="GMOM_JRA_WD">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_ww3dev"/>
+      <machine name="derecho" compiler="gnu" category="aux_ww3dev"/>
     </machines>
     <options>
       <option name="wallclock">01:00:00</option>
@@ -11,6 +12,7 @@
   <test name="ERS" grid="TL319_t061_wt061" compset="GMOM_JRA_WD">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_ww3dev"/>
+      <machine name="derecho" compiler="intel" category="aux_ww3dev"/>
     </machines>
     <options>
       <option name="wallclock">01:00:00</option>
@@ -19,6 +21,7 @@
   <test name="ERS" grid="T62_g17" compset="2000_DATM%NYF_SLND_DICE%SSMI_POP2_DROF%NYF_SGLC_WW3DEV">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_ww3dev"/>
+      <machine name="derecho" compiler="intel" category="aux_ww3dev"/>
     </machines>
     <options>
       <option name="wallclock">00:30:00</option>
@@ -27,6 +30,7 @@
   <test name="ERS" grid="T62_g17" compset="2000_DATM%NYF_SLND_CICE_POP2_DROF%NYF_SGLC_WW3DEV">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_ww3dev"/>
+      <machine name="derecho" compiler="intel" category="aux_ww3dev"/>
     </machines>
     <options>
       <option name="wallclock">00:30:00</option>


### PR DESCRIPTION
- Rremove readily available mod_def files
from config_component.xml and instead use
WW3_GRID_INP_DIR mechanism for all three grids.
Also update the grid_inp files to set calendar to
365 days, and to turn on tail pstokes contribution.
- add derecho tests
- bump up core WW3 version (pstokes tail contribution)

testing: aux_ww3dev.cheyenne