### PR TITLE
Turn on ICNUMERICS in namelist

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -55,7 +55,7 @@
     <default_value>$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}</default_value>
     <values>
       <value grid="_w%ww3a">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.231018</value>
-      <value grid="_w%gx3v7">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.240722</value>
+      <value grid="_w%wgx3v7">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.250428</value>
       <value grid="_w%wtx2_3v2">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.240722</value>
     </values>
     <group>case_comp</group>


### PR DESCRIPTION
This turns on ICNUMERICS by default in the WW3 namelist and points to a different ww3_grid.inp file.