### PR TITLE
Auto-generate initial conditions and improve grid-input staging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "WW3"]
 path = WW3
 url = https://github.com/ESCOMP/WW3.git
-fxtag = dev/unified_0.0.14
+fxtag = dev/unified_0.0.15
 fxrequired = AlwaysRequired
 fxDONOTUSEurl = https://github.com/ESCOMP/WW3.git
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "WW3"]
 path = WW3
 url = https://github.com/ESCOMP/WW3.git
-fxtag = dev/unified_0.0.15
+fxtag = dev/unified_0.1.0
 fxrequired = AlwaysRequired
 fxDONOTUSEurl = https://github.com/ESCOMP/WW3.git
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -208,19 +208,22 @@ def _prestage_inputs(case):
 
         # Copy ww3_inp and other needed info to ww3_moddef_create directory
         input_dir = case.get_value("WW3_GRID_INP_DIR")
-        files = os.listdir(input_dir)
-        for filename in files:
-            if not os.path.isfile(os.path.join(output_dir, filename)):
-                safe_copy(os.path.join(input_dir, filename), os.path.join(output_dir, filename))
+        if os.path.isdir(input_dir):
+            files = os.listdir(input_dir)
+            for filename in files:
+                if not os.path.isfile(os.path.join(output_dir, filename)):
+                    safe_copy(os.path.join(input_dir, filename), os.path.join(output_dir, filename))
                 
         # Create mod_def file using ww3_grid and the grid_input files
-        if os.path.isfile(os.path.join(output_dir,"ww3_grid")):
+        if not os.path.isfile(os.path.join(output_dir,"ww3_grid")):
+            logger.warning("ww3_grid file not found. The mod_def.ww3 file will be created after the build phase.")
+        elif not os.path.isfile(os.path.join(output_dir,"ww3_grid.inp")):
+            logger.warning("ww3_grid.inp file not found. The file will automatically be downloaded at the ./case.submit phase.")
+        else:
             run_cmd("./ww3_grid > mod_def.ww3.log", from_dir=output_dir)
             if not os.path.isfile(os.path.join(output_dir,"mod_def.ww3")):
                 raise RuntimeError("mod_def.ww3 was not created, check mod_def.ww3.log for errors.")
             shutil.move(os.path.join(output_dir,"mod_def.ww3"), os.path.join(rundir, "mod_def.ww3"))
-        else:
-            logger.warning("ww3_grid file not found. The mod_def.ww3 file will be created after the build phase.")
             
     else:
         # Use mod_def already created 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -61,19 +61,25 @@ def _create_namelists(case, confdir, namelist_infile, nmlgen, data_list_path):
         run_refcase = case.get_value("RUN_REFCASE")
         run_refdate = case.get_value("RUN_REFDATE")
         run_tod = case.get_value("RUN_REFTOD")
-        filename = "%s.ww3.r.%s-%s" %(run_refcase, run_refdate, run_tod)
+        base = "%s.ww3.r.%s-%s" %(run_refcase, run_refdate, run_tod)
+        # WW3 writes netCDF restarts by default, so prefer the netCDF reference
+        # restart. Fall back to a binary restart (backward compatibility) when
+        # that is what the reference case wrote.
+        if (os.path.isfile(os.path.join(rundir, base))
+                and not os.path.isfile(os.path.join(rundir, base + ".nc"))):
+            filename = base            # binary reference restart (fallback)
+        else:
+            filename = base + ".nc"    # netCDF reference restart (default)
         nmlgen.add_default("initfile", value=filename, ignore_abs_path=True)
     else:
+        # Initial (and hybrid) runs: an explicit initfile may be supplied via
+        # user_nl_ww3 (netCDF or binary). With no initfile, WW3 starts from
+        # in-core calm conditions -- no binary initial-condition file is needed.
         user_initfile = nmlgen.get_value("initfile")
-        if (case.get_value("WW3_MODDEF") != 'unset'
-                and not (user_initfile and user_initfile.strip().strip("'\"").strip())):
-            expect(False,
-                   "WW3_MODDEF is set to a user-supplied mod_def file, but no "
-                   "initfile was provided. When you supply your own WW3_MODDEF, "
-                   "you must also supply initfile via user_nl_ww3 (e.g., "
-                   "initfile = '/path/to/restart.ww3'). Alternatively, unset "
-                   "WW3_MODDEF to use the auto-generated calm_strt.ww3.")
-        nmlgen.add_default("initfile")
+        if user_initfile and user_initfile.strip().strip("'\"").strip():
+            nmlgen.add_default("initfile")
+        else:
+            nmlgen.set_value("initfile", "")
 
     # error check 
     dtcpl = basedt / int(ncpl)
@@ -203,16 +209,11 @@ def _prestage_inputs(case):
     bldroot = os.path.join(case.get_value("EXEROOT"),"wav","obj")
     bld_ww3_grid = os.path.join(bldroot, "ww3_grid") # executable to create mod_def.ww3 file
     if os.path.isfile(bld_ww3_grid):
-        bld_ww3_strt = os.path.join(bldroot, "ww3_strt") # executable to create ww3 i.c. file
-        if not os.path.isfile(bld_ww3_strt):
-            raise RuntimeError("ww3_strt executable not found in {} while ww3_grid is available".format(bldroot))
         ww3_moddef_dir = os.path.join(rundir, "ww3_moddef_create")
         if not os.path.exists(ww3_moddef_dir):
             os.makedirs(ww3_moddef_dir)
         if not os.path.exists(os.path.join(ww3_moddef_dir, "ww3_grid")):
             safe_copy(bld_ww3_grid, ww3_moddef_dir)
-        if not os.path.exists(os.path.join(ww3_moddef_dir, "ww3_strt")):
-            safe_copy(bld_ww3_strt, ww3_moddef_dir)
 
     if case.get_value("WW3_MODDEF") == 'unset':
         # Create output dir ww3_moddef_create if appropriate
@@ -238,17 +239,10 @@ def _prestage_inputs(case):
             run_cmd("./ww3_grid > mod_def.ww3.log", from_dir=output_dir)
             if not os.path.isfile(os.path.join(output_dir,"mod_def.ww3")):
                 raise RuntimeError("mod_def.ww3 was not created, check mod_def.ww3.log for errors.")
-            # Generate ww3_strt.ww3 file using ww3_strt executable and the grid_input files
-            if not os.path.isfile(os.path.join(output_dir,"ww3_strt")):
-                raise RuntimeError("ww3_strt file not found.")
-            if not os.path.isfile(os.path.join(output_dir,"ww3_strt.inp")):
-                raise RuntimeError("ww3_strt.inp file not found.")
-            run_cmd("./ww3_strt > ww3_strt.ww3.log", from_dir=output_dir)
-            if not os.path.isfile(os.path.join(output_dir,"restart.ww3")):
-                raise RuntimeError("restart.ww3 was not created, check ww3_strt.ww3.log for errors.")
-            # Copy mod_def.ww3 and ww3_strt.ww3 files to rundir
+            # Copy mod_def.ww3 to rundir. No binary initial-condition file is
+            # generated: WW3 initial runs start from in-core calm conditions
+            # (or a user-supplied initfile), and restarts are netCDF.
             shutil.move(os.path.join(output_dir,"mod_def.ww3"), os.path.join(rundir, "mod_def.ww3"))
-            shutil.move(os.path.join(output_dir,"restart.ww3"), os.path.join(rundir, "calm_strt.ww3"))
 
     else:
         # Use mod_def already created 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -36,6 +36,7 @@ def _create_namelists(case, confdir, namelist_infile, nmlgen, data_list_path):
     run_type = case.get_value("RUN_TYPE")
     config["runtype"] = run_type
     config["wav_grid"] = case.get_value("WAV_GRID")
+    config["ww3_moddef"] = case.get_value("WW3_MODDEF")
 
     rundir = case.get_value("RUNDIR")
     start_date = case.get_value("RUN_STARTDATE")
@@ -63,6 +64,15 @@ def _create_namelists(case, confdir, namelist_infile, nmlgen, data_list_path):
         filename = "%s.ww3.r.%s-%s" %(run_refcase, run_refdate, run_tod)
         nmlgen.add_default("initfile", value=filename, ignore_abs_path=True)
     else:
+        user_initfile = nmlgen.get_value("initfile")
+        if (case.get_value("WW3_MODDEF") != 'unset'
+                and not (user_initfile and user_initfile.strip().strip("'\"").strip())):
+            expect(False,
+                   "WW3_MODDEF is set to a user-supplied mod_def file, but no "
+                   "initfile was provided. When you supply your own WW3_MODDEF, "
+                   "you must also supply initfile via user_nl_ww3 (e.g., "
+                   "initfile = '/path/to/restart.ww3'). Alternatively, unset "
+                   "WW3_MODDEF to use the auto-generated calm_strt.ww3.")
         nmlgen.add_default("initfile")
 
     # error check 
@@ -190,15 +200,19 @@ def _prestage_inputs(case):
     rundir = case.get_value("RUNDIR")
 
     # Create rundir/ww3_moddef_create
-    filename = "ww3_grid"
     bldroot = os.path.join(case.get_value("EXEROOT"),"wav","obj")
-    item = os.path.join(bldroot, filename)
-    if os.path.isfile(item):
+    bld_ww3_grid = os.path.join(bldroot, "ww3_grid") # executable to create mod_def.ww3 file
+    if os.path.isfile(bld_ww3_grid):
+        bld_ww3_strt = os.path.join(bldroot, "ww3_strt") # executable to create ww3 i.c. file
+        if not os.path.isfile(bld_ww3_strt):
+            raise RuntimeError("ww3_strt executable not found in {} while ww3_grid is available".format(bldroot))
         ww3_moddef_dir = os.path.join(rundir, "ww3_moddef_create")
         if not os.path.exists(ww3_moddef_dir):
             os.makedirs(ww3_moddef_dir)
-        if not os.path.exists(os.path.join(ww3_moddef_dir,filename)):
-            safe_copy(item, ww3_moddef_dir)
+        if not os.path.exists(os.path.join(ww3_moddef_dir, "ww3_grid")):
+            safe_copy(bld_ww3_grid, ww3_moddef_dir)
+        if not os.path.exists(os.path.join(ww3_moddef_dir, "ww3_strt")):
+            safe_copy(bld_ww3_strt, ww3_moddef_dir)
 
     if case.get_value("WW3_MODDEF") == 'unset':
         # Create output dir ww3_moddef_create if appropriate
@@ -220,11 +234,22 @@ def _prestage_inputs(case):
         elif not os.path.isfile(os.path.join(output_dir,"ww3_grid.inp")):
             logger.warning("ww3_grid.inp file not found. The file will automatically be downloaded at the ./case.submit phase.")
         else:
+            # Generate mod_def.ww3 file using ww3_grid executable and the grid_input files
             run_cmd("./ww3_grid > mod_def.ww3.log", from_dir=output_dir)
             if not os.path.isfile(os.path.join(output_dir,"mod_def.ww3")):
                 raise RuntimeError("mod_def.ww3 was not created, check mod_def.ww3.log for errors.")
+            # Generate ww3_strt.ww3 file using ww3_strt executable and the grid_input files
+            if not os.path.isfile(os.path.join(output_dir,"ww3_strt")):
+                raise RuntimeError("ww3_strt file not found.")
+            if not os.path.isfile(os.path.join(output_dir,"ww3_strt.inp")):
+                raise RuntimeError("ww3_strt.inp file not found.")
+            run_cmd("./ww3_strt > ww3_strt.ww3.log", from_dir=output_dir)
+            if not os.path.isfile(os.path.join(output_dir,"restart.ww3")):
+                raise RuntimeError("restart.ww3 was not created, check ww3_strt.ww3.log for errors.")
+            # Copy mod_def.ww3 and ww3_strt.ww3 files to rundir
             shutil.move(os.path.join(output_dir,"mod_def.ww3"), os.path.join(rundir, "mod_def.ww3"))
-            
+            shutil.move(os.path.join(output_dir,"restart.ww3"), os.path.join(rundir, "calm_strt.ww3"))
+
     else:
         # Use mod_def already created 
         mod_def_in = case.get_value("WW3_MODDEF")

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -55,7 +55,7 @@
     <default_value>$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}</default_value>
     <values>
       <value grid="_w%ww3a">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.231018</value>
-      <value grid="_w%wgx3v7">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.250428</value>
+      <value grid="_w%wgx3v7">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.260527</value>
       <value grid="_w%wtx2_3v2">$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}.240722</value>
     </values>
     <group>case_comp</group>

--- a/cime_config/namelist_definition_ww3.xml
+++ b/cime_config/namelist_definition_ww3.xml
@@ -80,6 +80,78 @@
     </desc>
   </entry>
 
+  <entry id="grid_inp_mapsta">
+    <type>char</type>
+    <group>prestage_only</group>
+    <category>prestage_only</category>
+    <input_pathname>abs</input_pathname>
+    <values>
+      <value>UNSET</value>
+      <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/g37_mapsta.inp</value>
+    </values>
+    <desc>Grid mask file; listed so check_input_data can download it.</desc>
+  </entry>
+
+  <entry id="grid_inp_bottom">
+    <type>char</type>
+    <group>prestage_only</group>
+    <category>prestage_only</category>
+    <input_pathname>abs</input_pathname>
+    <values>
+      <value>UNSET</value>
+      <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/g37_bottom.inp</value>
+    </values>
+    <desc>Grid bottom depth file; listed so check_input_data can download it.</desc>
+  </entry>
+
+  <entry id="grid_inp_y">
+    <type>char</type>
+    <group>prestage_only</group>
+    <category>prestage_only</category>
+    <input_pathname>abs</input_pathname>
+    <values>
+      <value>UNSET</value>
+      <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/g37_y.inp</value>
+    </values>
+    <desc>Grid y-coordinate file; listed so check_input_data can download it.</desc>
+  </entry>
+
+  <entry id="grid_inp_x">
+    <type>char</type>
+    <group>prestage_only</group>
+    <category>prestage_only</category>
+    <input_pathname>abs</input_pathname>
+    <values>
+      <value>UNSET</value>
+      <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/g37_x.inp</value>
+    </values>
+    <desc>Grid x-coordinate file; listed so check_input_data can download it.</desc>
+  </entry>
+
+  <entry id="grid_inp">
+    <type>char</type>
+    <group>prestage_only</group>
+    <category>prestage_only</category>
+    <input_pathname>abs</input_pathname>
+    <values>
+      <value>UNSET</value>
+      <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/ww3_grid.inp</value>
+    </values>
+    <desc>Grid input file; listed so check_input_data can download it.</desc>
+  </entry>
+
+  <entry id="grid_inp_strt">
+    <type>char</type>
+    <group>prestage_only</group>
+    <category>prestage_only</category>
+    <input_pathname>abs</input_pathname>
+    <values>
+      <value>UNSET</value>
+      <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/ww3_strt.inp</value>
+    </values>
+    <desc>Grid strt file; listed so check_input_data can download it.</desc>
+  </entry>
+
   <entry id="dtmax">
     <type>real</type>
     <group>ww3_inparm</group>

--- a/cime_config/namelist_definition_ww3.xml
+++ b/cime_config/namelist_definition_ww3.xml
@@ -35,16 +35,12 @@
     <values>
       <value runtype="startup">"" </value>
       <value runtype="hybrid" >"" </value>
-      <value runtype="startup"	wav_grid="ww3a">$DIN_LOC_ROOT/wav/ww3/ww3a.restart.ww3.calm.wwver7.14.220119</value>
-      <value runtype="hybrid"	wav_grid="ww3a">$DIN_LOC_ROOT/wav/ww3/ww3a.restart.ww3.calm.wwver7.14.220119</value>
-      <value runtype="startup"	wav_grid="wgx3v7">$DIN_LOC_ROOT/wav/ww3/wgx3v7.restart.ww3.calm.240722</value>
-      <value runtype="hybrid"	wav_grid="wgx3v7">$DIN_LOC_ROOT/wav/ww3/wgx3v7.restart.ww3.calm.240722</value>
-      <value runtype="startup"	wav_grid="wtx2_3v2">$DIN_LOC_ROOT/wav/ww3/wt232.restart.ww3.calm.240722</value>
-      <value runtype="hybrid"	wav_grid="wtx2_3v2">$DIN_LOC_ROOT/wav/ww3/wt232.restart.ww3.calm.240722</value>
-      <value runtype="startup"	wav_grid="wtnx1v4nw">' '</value>
-      <value runtype="hybrid"	wav_grid="wtnx1v4nw">' '</value>
-      <value runtype="startup"	wav_grid="wtnx1v4">$DIN_LOC_ROOT/wav/ww3/wtnx1v4.restart.ww3.230308</value>
-      <value runtype="hybrid"	wav_grid="wtnx1v4">$DIN_LOC_ROOT/wav/ww3/wtnx1v4.restart.ww3.230308</value>
+      <value runtype="startup"	ww3_moddef="unset">"calm_strt.ww3" </value>
+      <value runtype="hybrid"	ww3_moddef="unset">"calm_strt.ww3" </value>
+      <value runtype="startup"	wav_grid="wtnx1v4nw"	ww3_moddef="unset">' '</value>
+      <value runtype="hybrid"	wav_grid="wtnx1v4nw"	ww3_moddef="unset">' '</value>
+      <value runtype="startup"	wav_grid="wtnx1v4"	ww3_moddef="unset">$DIN_LOC_ROOT/wav/ww3/wtnx1v4.restart.ww3.230308</value>
+      <value runtype="hybrid"	wav_grid="wtnx1v4"	ww3_moddef="unset">$DIN_LOC_ROOT/wav/ww3/wtnx1v4.restart.ww3.230308</value>
     </values>
     <desc>
       Initial condition file.
@@ -87,7 +83,9 @@
     <input_pathname>abs</input_pathname>
     <values>
       <value>UNSET</value>
+      <value wav_grid="ww3a">$WW3_GRID_INP_DIR/ww3a_mapsta.inp</value>
       <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/g37_mapsta.inp</value>
+      <value wav_grid="wtx2_3v2">$WW3_GRID_INP_DIR/t232_mapsta.inp</value>
     </values>
     <desc>Grid mask file; listed so check_input_data can download it.</desc>
   </entry>
@@ -99,7 +97,9 @@
     <input_pathname>abs</input_pathname>
     <values>
       <value>UNSET</value>
+      <value wav_grid="ww3a">$WW3_GRID_INP_DIR/ww3a_bottom.inp</value>
       <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/g37_bottom.inp</value>
+      <value wav_grid="wtx2_3v2">$WW3_GRID_INP_DIR/t232_bottom.inp</value>
     </values>
     <desc>Grid bottom depth file; listed so check_input_data can download it.</desc>
   </entry>
@@ -112,6 +112,7 @@
     <values>
       <value>UNSET</value>
       <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/g37_y.inp</value>
+      <value wav_grid="wtx2_3v2">$WW3_GRID_INP_DIR/t232_y.inp</value>
     </values>
     <desc>Grid y-coordinate file; listed so check_input_data can download it.</desc>
   </entry>
@@ -124,6 +125,7 @@
     <values>
       <value>UNSET</value>
       <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/g37_x.inp</value>
+      <value wav_grid="wtx2_3v2">$WW3_GRID_INP_DIR/t232_x.inp</value>
     </values>
     <desc>Grid x-coordinate file; listed so check_input_data can download it.</desc>
   </entry>
@@ -135,7 +137,9 @@
     <input_pathname>abs</input_pathname>
     <values>
       <value>UNSET</value>
+      <value wav_grid="ww3a">$WW3_GRID_INP_DIR/ww3_grid.inp</value>
       <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/ww3_grid.inp</value>
+      <value wav_grid="wtx2_3v2">$WW3_GRID_INP_DIR/ww3_grid.inp</value>
     </values>
     <desc>Grid input file; listed so check_input_data can download it.</desc>
   </entry>
@@ -147,7 +151,9 @@
     <input_pathname>abs</input_pathname>
     <values>
       <value>UNSET</value>
+      <value wav_grid="ww3a">$WW3_GRID_INP_DIR/ww3_strt.inp</value>
       <value wav_grid="wgx3v7">$WW3_GRID_INP_DIR/ww3_strt.inp</value>
+      <value wav_grid="wtx2_3v2">$WW3_GRID_INP_DIR/ww3_strt.inp</value>
     </values>
     <desc>Grid strt file; listed so check_input_data can download it.</desc>
   </entry>
@@ -226,6 +232,21 @@
     <category>setup</category>
     <values>
       <value>'99990101 0'</value>
+    </values>
+  </entry>
+
+  <entry id="domain_percent_iostyp">
+    <type>integer</type>
+    <group>domain_nml</group>
+    <category>setup</category>
+    <desc>
+      WW3 restart/output I/O type. 0 = no dedicated output process, each process
+      writes its own data (requires a parallel file system); 1 = no dedicated
+      output process, gather to a single writer (any file system); 2 = single
+      dedicated output process; 3 = multiple dedicated output processes.
+    </desc>
+    <values>
+      <value>1</value>
     </values>
   </entry>
 

--- a/cime_config/testdefs/testlist_ww3.xml
+++ b/cime_config/testdefs/testlist_ww3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="SMS_D_Ld1" grid="TL319_t232" compset="CW_JRA">
+  <test name="SMS_Ld1" grid="TL319_t232" compset="CW_JRA">
     <machines>
       <machine name="derecho" compiler="gnu" category="aux_ww3"/>
     </machines>
@@ -21,10 +21,18 @@
       <machine name="derecho" compiler="intel" category="aux_ww3"/>
     </machines>
     <options>
-      <option name="wallclock">01:00:00</option>
+      <option name="wallclock">02:00:00</option>
     </options>
   </test>
-  <test name="SMS" grid="TL319_t232_wt232" compset="GW_JRA" testmods="ww3/legacy_cpl">
+  <test name="ERI" grid="TL319_t232" compset="GW_JRA">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_ww3"/>
+    </machines>
+    <options>
+      <option name="wallclock">02:00:00</option>
+    </options>
+  </test>
+  <test name="SMS" grid="TL319_t232" compset="GW_JRA" testmods="ww3/legacy_cpl">
     <machines>
       <machine name="derecho" compiler="gnu" category="aux_ww3"/>
     </machines>


### PR DESCRIPTION
  Generate WW3 initial conditions at build time via `ww3_strt` instead of
  pre-staging per-grid restart files, and harden grid-input staging.

  ## Changes
  - Auto-generate the calm-start IC (`calm_strt.ww3`) via `ww3_strt`; a
    user-supplied `WW3_MODDEF` now requires an explicit `initfile`.
  - Guard `buildnml` against missing `WW3_GRID_INP_DIR`/inputs, warning
    instead of crashing and deferring generation past the build phase.
  - Add grid input entries for `wgx3v7`, `ww3a`, and `wtx2_3v2`.
  - Add `domain_percent_iostyp` namelist entry (default 1).
  - Bump `wgx3v7` grid_inp data and the WW3 submodule (always build
    `ww3_strt`; IOSTYP restart-gather deadlock fix).

This PR is in conjunction with https://github.com/ESCOMP/WW3/pull/39

Fixes: #16 

Testing: aux_ww3. all b4b.